### PR TITLE
[#M104] - BM/AJ - Extend React Native .babelrc instead of rolling our own

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-    "presets": ["es2015", "react"],
-    "plugins": ["transform-object-rest-spread"]
+    "extends": "react-native/packager/react-packager/.babelrc"
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "redux": "^3.3.1"
   },
   "devDependencies": {
-    "babel-plugin-transform-object-rest-spread": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-react": "^6.5.0",
     "babel-register": "^6.5.2",
     "chai": "^3.5.0",
     "enzyme": "^2.0.0",


### PR DESCRIPTION
- This fixes an issue the app wouldn't start up unless it was using a
  cached .babelrc that wouldn't override the facebook default.
