### PR TITLE
Extract LocationService with full test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mockery": "^1.4.0",
     "react-dom": "^0.14.7",
     "react-native-mock": "0.0.6",
+    "sinon-chai": "^2.8.0",
     "wd": "^0.4.0"
   }
 }

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -9,7 +9,7 @@ import React, {
 } from 'react-native';
 
 import { initialState as initLoc } from '../redux/modules/userLocation';
-import {startLocationPolling, onLocationChanged } from '../services/LocationService.android';
+import { startLocationPolling, onLocationChanged } from '../services/LocationService.android';
 
 import MapView from '../components/MapView';
 import UserLocationTexBox from '../components/UserLocationTextBox';
@@ -19,6 +19,7 @@ export default class Root extends Component {
   static defaultProps = { userLocation: initLoc};
 
   componentDidMount() {
+    console.log('userlocationchanged', this.props.userLocationChanged);
     startLocationPolling();
     onLocationChanged(this.props.userLocationChanged);
   }

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -9,7 +9,7 @@ import React, {
 } from 'react-native';
 
 import { initialState as initLoc } from '../redux/modules/userLocation';
-const { LOSTLocationProvider: { startLocationPolling, HIGH_ACCURACY } } = NativeModules;
+import {startLocationPolling, onLocationChanged } from '../services/LocationService.android';
 
 import MapView from '../components/MapView';
 import UserLocationTexBox from '../components/UserLocationTextBox';
@@ -19,11 +19,8 @@ export default class Root extends Component {
   static defaultProps = { userLocation: initLoc};
 
   componentDidMount() {
-    startLocationPolling(500, 0.1, HIGH_ACCURACY);
-    DeviceEventEmitter.addListener(
-      'location_changed',
-      userLocation => this.props.userLocationChanged({...userLocation})
-    );
+    startLocationPolling();
+    onLocationChanged(this.props.userLocationChanged);
   }
 
   render() {

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -19,7 +19,6 @@ export default class Root extends Component {
   static defaultProps = { userLocation: initLoc};
 
   componentDidMount() {
-    console.log('userlocationchanged', this.props.userLocationChanged);
     startLocationPolling();
     onLocationChanged(this.props.userLocationChanged);
   }

--- a/src/services/LocationService.android.js
+++ b/src/services/LocationService.android.js
@@ -1,0 +1,15 @@
+import {
+  DeviceEventEmitter,
+  NativeModules
+} from 'react-native';
+
+const LocationProvider = NativeModules.LOSTLocationProvider;
+export const FREQUENCY = 500;
+export const DISTANCE = 1;
+export const ACCURACY = LocationProvider.HIGH_ACCURACY;
+
+export const startLocationPolling = () =>
+  LocationProvider.startLocationPolling(FREQUENCY, DISTANCE, ACCURACY);
+
+export const onLocationChanged = callback =>
+  DeviceEventEmitter.addListener('location_changed', callback);

--- a/test/support/FakeDom.js
+++ b/test/support/FakeDom.js
@@ -1,0 +1,7 @@
+import jsdom from 'jsdom';
+
+export const makeFakeDom = () => {
+  const doc = jsdom.jsdom('<!doctype html><html><body></body></html>');
+  global.document = doc;
+  global.window = doc.defaultView;
+};

--- a/test/unit/components/Root.spec.js
+++ b/test/unit/components/Root.spec.js
@@ -1,20 +1,32 @@
 import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 chai.should();
+chai.use(sinonChai);
+
+import { makeFakeDom } from '../../support/FakeDom';
 
 import React, { View } from "react-native";
-import { shallow, render } from "enzyme";
+import { shallow, render, mount } from "enzyme";
+import { createStore } from 'redux';
+import reducer from '../../../src/redux/reducer';
+import { userLocationChanged } from '../../../src/redux/modules/userLocation';
 
+import App from '../../../src/containers/App';
 import Root from "../../../src/components/Root";
 import UserLocationTextBox from '../../../src/components/UserLocationTextBox';
 import MapView from "../../../src/components/MapView.android.js";
+
+import * as LocationService from '../../../src/services/LocationService.android'
+
 
 describe("Root component", () => {
 
   describe("layout", () => {
 
-    describe('UserLocationTextBox', () => {
+    const root = shallow(<Root/>);
 
-      const root = shallow(<Root/>);
+    describe('UserLocationTextBox', () => {
 
       it('should exist', () => {
         root.find(UserLocationTextBox).is("UserLocationTextBox").should.be.true;
@@ -29,8 +41,6 @@ describe("Root component", () => {
 
     describe("MapView", () => {
 
-      const root = shallow(<Root/>);
-
       it("should exist", () => {
         root.find(MapView).is("OsmDroidMapView").should.be.true;
       });
@@ -42,6 +52,24 @@ describe("Root component", () => {
       it("should have zoom level", () => {
         root.find(MapView).props().zoom.should.exist;
       });
+    });
+  });
+
+  describe('event handlers', () => {
+
+    makeFakeDom();
+    const startLocationPolling = sinon.stub(LocationService, 'startLocationPolling');
+    const onLocationChanged = sinon.stub(LocationService, 'onLocationChanged');
+    mount(<Root userLocationChanged={sinon.spy()}/>);
+
+    it('starts location polling', () => {
+      startLocationPolling.should.have.been.calledOnce;
+      startLocationPolling.restore();
+    });
+
+    it('registers location changed callback', () => {
+      onLocationChanged.should.have.been.calledOnce;
+      onLocationChanged.restore();
     });
   });
 });

--- a/test/unit/components/Root.spec.js
+++ b/test/unit/components/Root.spec.js
@@ -40,7 +40,7 @@ describe("Root component", () => {
       });
 
       it("should have zoom level", () => {
-        root.find(MapView).props().zoom.should.be.a('number');
+        root.find(MapView).props().zoom.should.exist;
       });
     });
   });

--- a/test/unit/services/LocationService.spec.js
+++ b/test/unit/services/LocationService.spec.js
@@ -1,0 +1,46 @@
+import chai from "chai";
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chai.should();
+chai.use(sinonChai);
+
+import React, { DeviceEventEmitter } from "react-native";
+
+import {
+  FREQUENCY,
+  DISTANCE,
+  ACCURACY,
+  startLocationPolling,
+  onLocationChanged
+} from "../../../src/services/LocationService.android";
+
+describe("LocationService", () => {
+
+  const locationProvider = React.NativeModules.LOSTLocationProvider;
+
+  describe("#startLocationPolling", () => {
+
+    it("should start location polling with correct parameters", () =>{
+      const startPolling = sinon.stub(locationProvider, 'startLocationPolling');
+      startLocationPolling(locationProvider);
+
+      startPolling.should.have.been.calledWith(FREQUENCY, DISTANCE, ACCURACY);
+      startPolling.restore();
+    });
+  });
+
+  describe('#onLocationChanged', () => {
+
+    it("should register a callback to handle 'location_changed' events", () => {
+      const spy = sinon.spy();
+      startLocationPolling();
+      onLocationChanged(spy);
+
+      DeviceEventEmitter.emit('location_changed');
+      DeviceEventEmitter.emit('location_changed');
+
+      spy.should.have.been.calledTwice;
+    });
+  });
+});


### PR DESCRIPTION
- extract interactions with location provider to service layer
- decouple starting location polling from registering location changed callback
- test location polling start, handling location changed events, connecting to service from component

DISCOVERY: you can just call `DeviceEmitter.emit('some_event')` from anywhere anytime you like!!! (great for testing websockets and/or any other code that handles events from the native layer!)
